### PR TITLE
Make the hhea ascent/descent match the typo metrics.

### DIFF
--- a/sources/xits-bold.sfd
+++ b/sources/xits-bold.sfd
@@ -35,9 +35,9 @@ OS2WinAscent: 0
 OS2WinAOffset: 1
 OS2WinDescent: 0
 OS2WinDOffset: 1
-HheadAscent: 1055
+HheadAscent: 750
 HheadAOffset: 0
-HheadDescent: -455
+HheadDescent: -250
 HheadDOffset: 0
 OS2SubXSize: 500
 OS2SubYSize: 500

--- a/sources/xits-bolditalic.sfd
+++ b/sources/xits-bolditalic.sfd
@@ -35,9 +35,9 @@ OS2WinAscent: 38
 OS2WinAOffset: 1
 OS2WinDescent: 96
 OS2WinDOffset: 1
-HheadAscent: 1055
+HheadAscent: 750
 HheadAOffset: 0
-HheadDescent: -455
+HheadDescent: -250
 HheadDOffset: 0
 OS2SubXSize: 500
 OS2SubYSize: 500

--- a/sources/xits-italic.sfd
+++ b/sources/xits-italic.sfd
@@ -35,9 +35,9 @@ OS2WinAscent: 32
 OS2WinAOffset: 1
 OS2WinDescent: 150
 OS2WinDOffset: 1
-HheadAscent: 1055
+HheadAscent: 750
 HheadAOffset: 0
-HheadDescent: -455
+HheadDescent: -250
 HheadDOffset: 0
 OS2SubXSize: 500
 OS2SubYSize: 500

--- a/sources/xits-math.sfd
+++ b/sources/xits-math.sfd
@@ -34,9 +34,9 @@ OS2WinAscent: 32
 OS2WinAOffset: 1
 OS2WinDescent: 12
 OS2WinDOffset: 1
-HheadAscent: 1055
+HheadAscent: 750
 HheadAOffset: 0
-HheadDescent: -455
+HheadDescent: -250
 HheadDOffset: 0
 OS2SubXSize: 500
 OS2SubYSize: 500

--- a/sources/xits-mathbold.sfd
+++ b/sources/xits-mathbold.sfd
@@ -33,9 +33,9 @@ OS2WinAscent: 32
 OS2WinAOffset: 1
 OS2WinDescent: 12
 OS2WinDOffset: 1
-HheadAscent: 1055
+HheadAscent: 750
 HheadAOffset: 0
-HheadDescent: -455
+HheadDescent: -250
 HheadDOffset: 0
 OS2SubXSize: 500
 OS2SubYSize: 500

--- a/sources/xits-regular.sfd
+++ b/sources/xits-regular.sfd
@@ -35,9 +35,9 @@ OS2WinAscent: 32
 OS2WinAOffset: 1
 OS2WinDescent: 12
 OS2WinDOffset: 1
-HheadAscent: 1055
+HheadAscent: 750
 HheadAOffset: 0
-HheadDescent: -455
+HheadDescent: -250
 HheadDOffset: 0
 OS2SubXSize: 500
 OS2SubYSize: 500


### PR DESCRIPTION
This makes hhea ascent/descent match the typo metrics to fix rendering bugs in browsers.

Feel free to ignore that pull request if the hhea ascent/descent were intentionally chosen larger.
